### PR TITLE
chore(CI): create test placeholder and package build

### DIFF
--- a/.github/workflows/pr-commit-stage.yml
+++ b/.github/workflows/pr-commit-stage.yml
@@ -85,7 +85,7 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}/${{ github.head_ref }}:${{ github.sha }}
+            ghcr.io/${{ github.repository }}:${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
             ghcr.io/${{ github.repository }}/${{ github.head_ref }}:latest
 
       - name: Deploy to AWS using Copilot

--- a/.github/workflows/pr-commit-stage.yml
+++ b/.github/workflows/pr-commit-stage.yml
@@ -85,7 +85,7 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}:${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+            ghcr.io/${{ github.repository }}/${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}:${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
             ghcr.io/${{ github.repository }}/${{ github.head_ref }}:latest
 
       - name: Deploy to AWS using Copilot

--- a/.github/workflows/pr-commit-stage.yml
+++ b/.github/workflows/pr-commit-stage.yml
@@ -6,7 +6,7 @@ on:
     branches: [ main ]
 
 jobs:
-  lint:
+  checkout_and_lint:
     runs-on: ubuntu-latest
 
     steps:
@@ -24,7 +24,7 @@ jobs:
           cache-name: cache-node-modules
         with:
           # Cache dependencies using a key for installers and dependencies
-          path: ~/.npm
+          path: node_modules
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-build-${{ env.cache-name }}-
@@ -36,3 +36,61 @@ jobs:
 
       - name: Run Lint
         run: npm run lint
+
+  test:
+    needs: checkout_and_lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Cache Node Modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # Cache dependencies using a key for installers and dependencies
+          path: node_modules
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - name: No-op Test Placeholder
+        run: echo "No tests implemented yet"
+
+  build_and_package_app:
+    needs: test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Cache Node Modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # Cache dependencies using a key for installers and dependencies
+          path: node_modules
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - name: Build Next.js App
+        run: npm run build
+
+      - name: Package Build Artifacts
+        run: |
+          tar -czf nextjs-build.tar.gz .next # Add other necessary files or directories
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: nextjs-build
+          path: nextjs-build.tar.gz

--- a/.github/workflows/pr-commit-stage.yml
+++ b/.github/workflows/pr-commit-stage.yml
@@ -106,8 +106,8 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            📦 New Docker Image has been pushed to Github Container Registry (GHCR)!
-            Image: ${{ steps.docker_build.outputs.image }}
+            📦 New Docker Image has been pushed to Github Container Registry (GHCR)
+            Image: ${{ steps.generate_ghcr_tag.outputs.image }}
 
 
       - name: Deploy to AWS using Copilot

--- a/.github/workflows/pr-commit-stage.yml
+++ b/.github/workflows/pr-commit-stage.yml
@@ -45,6 +45,11 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v2
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14.17'
+
       - name: Cache Node Modules
         uses: actions/cache@v2
         env:

--- a/.github/workflows/pr-commit-stage.yml
+++ b/.github/workflows/pr-commit-stage.yml
@@ -61,36 +61,35 @@ jobs:
       - name: No-op Test Placeholder
         run: echo "No tests implemented yet"
 
-  build_and_package_app:
-    needs: test
+  build-and-deploy:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
 
-      - name: Cache Node Modules
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-node-modules
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v1
         with:
-          # Cache dependencies using a key for installers and dependencies
-          path: node_modules
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build Next.js App
-        run: npm run build
+      - name: Build and Push Docker Image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/your-app:latest
 
-      - name: Package Build Artifacts
+      - name: Deploy to AWS using Copilot
+        if: false # This condition effectively disables the step until copilot is set up
         run: |
-          tar -czf nextjs-build.tar.gz .next # Add other necessary files or directories
-
-      - name: Upload Artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: nextjs-build
-          path: nextjs-build.tar.gz
+          copilot svc deploy --name your-service-name --env your-environment-name
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: your-aws-region # e.g., us-east-1

--- a/.github/workflows/pr-commit-stage.yml
+++ b/.github/workflows/pr-commit-stage.yml
@@ -68,6 +68,9 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v2
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
@@ -81,6 +84,7 @@ jobs:
       - name: Build and Push Docker Image
         uses: docker/build-push-action@v2
         with:
+          platforms: linux/amd64,linux/arm64/v8
           context: .
           file: ./Dockerfile
           push: true

--- a/.github/workflows/pr-commit-stage.yml
+++ b/.github/workflows/pr-commit-stage.yml
@@ -86,6 +86,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: generate ghcr tag
+        id: generate_ghcr_tag
+        run: echo "::set-output name=image::ghcr.io/${{ github.repository }}/${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}:${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}"
+
       - name: Build and Push Docker Image
         uses: docker/build-push-action@v2
         with:
@@ -94,8 +98,17 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}/${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}:${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-            ghcr.io/${{ github.repository }}/${{ github.head_ref }}:latest
+            ${{ steps.generate_ghcr_tag.outputs.image }}
+            ghcr.io/${{ github.repository }}/${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}:latest
+
+      - name: Comment PR with GHCR details
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            📦 New Docker Image has been pushed to Github Container Registry (GHCR)!
+            Image: ${{ steps.docker_build.outputs.image }}
+
 
       - name: Deploy to AWS using Copilot
         if: false # This condition effectively disables the step until copilot is set up

--- a/.github/workflows/pr-commit-stage.yml
+++ b/.github/workflows/pr-commit-stage.yml
@@ -62,6 +62,7 @@ jobs:
         run: echo "No tests implemented yet"
 
   build-and-deploy:
+    needs: test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -83,7 +84,9 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          tags: ghcr.io/${{ github.repository_owner }}/your-app:latest
+          tags: |
+            ghcr.io/${{ github.repository }}/${{ github.head_ref }}:${{ github.sha }}
+            ghcr.io/${{ github.repository }}/${{ github.head_ref }}:latest
 
       - name: Deploy to AWS using Copilot
         if: false # This condition effectively disables the step until copilot is set up

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+# Stage 1: Building the code
+FROM node:14.17-alpine as builder
+
+WORKDIR /app
+
+# Copy package.json and package-lock.json
+COPY package*.json ./
+
+# Install dependencies
+RUN npm install
+
+# Copy the rest of your app's source code from your host to your image filesystem.
+COPY . .
+
+# Build the Next.js app
+RUN npm run build
+
+# Stage 2: Run the Next.js app
+FROM node:14.17-alpine
+
+WORKDIR /app
+
+# Copy the build output to the new container
+COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/node_modules ./node_modules
+# COPY --from=builder /app/public ./public
+COPY --from=builder /app/package.json ./package.json
+
+# Expose the port the app runs on
+EXPOSE 3000
+
+# Start the app
+CMD ["npm", "start"]
+


### PR DESCRIPTION
- Create a placeholder job for when tests are ported over.
- Create a docker image and push it to github container registry (GHCR)
  - this will be later used when deploying via AWS copilot