### PR TITLE
Update Several Hover-State Colors to `ow-blue`

### DIFF
--- a/components/datasets/card-item/_styles.scss
+++ b/components/datasets/card-item/_styles.scss
@@ -21,10 +21,10 @@
 
   &.-active {
     border: none;
-    box-shadow: 0 0 0 2px $dark-pink, 0 1px 6px 0 rgba(0,0,0,.0);
+    box-shadow: 0 0 0 2px $ow-blue, 0 1px 6px 0 rgba(0,0,0,.0);
 
     &:hover {
-      box-shadow: 0 0 0 2px $dark-pink, 0 20px 30px rgba(0,0,0,.2);
+      box-shadow: 0 0 0 2px $ow-blue, 0 20px 30px rgba(0,0,0,.2);
     }
   }
 

--- a/copilot/environments/minor-color-updates/manifest.yml
+++ b/copilot/environments/minor-color-updates/manifest.yml
@@ -1,0 +1,21 @@
+# The manifest for the "minor-color-updates" environment.
+# Read the full specification for the "Environment" type at:
+#  https://aws.github.io/copilot-cli/docs/manifest/environment/
+
+# Your environment name will be used in naming your resources like VPC, cluster, etc.
+name: minor-color-updates
+type: Environment
+
+# Import your own VPC and subnets or configure how they should be created.
+# network:
+#   vpc:
+#     id:
+
+# Configure the load balancers in your environment, once created.
+# http:
+#   public:
+#   private:
+
+# Configure observability for your environment resources.
+observability:
+  container_insights: false

--- a/css/components/form/select.scss
+++ b/css/components/form/select.scss
@@ -239,7 +239,7 @@
   padding-right: 15px;
 }
 .Select-arrow {
-  @include arrow(8px, 2px, $dark-pink, 'down');
+  @include arrow(8px, 2px, $ow-blue, 'down');
 }
 .is-open .Select-arrow,
 .Select-arrow-zone:hover > .Select-arrow {

--- a/css/components/ui/button.scss
+++ b/css/components/ui/button.scss
@@ -1,6 +1,6 @@
-$btn-bg-hover-color: rgba(195, 45, 123,0.05);
+$btn-bg-hover-color: rgba(76, 136, 215,0.05);
 $btn-bg-hover-alt-color: rgba(255, 255, 255, 0.1);
-$btn-border-color: rgba(195, 45, 123, 0.3);
+$btn-border-color: rgba(76, 136, 215, 0.3);
 $btn-border-alt-color: rgba(255, 255, 255, 0.3);
 $btn-hover-shadow: 0 20px 30px 0 rgba(0, 0, 0, 0.2);
 

--- a/css/components/ui/modal2.scss
+++ b/css/components/ui/modal2.scss
@@ -78,7 +78,7 @@
     }
 
     &:hover {
-      svg { fill: $dark-pink; }
+      svg { fill: $ow-blue; }
     }
   }
 


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?

Hover states are still showing as `dark-pink`

## What is the new behavior?

Hover states are now showing as `ow-blue`

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
